### PR TITLE
[#1] Undefined written if no example is returned by API Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ function writeMeaningToFile(inputStream, filename) {
         toWrite += "    - " + meaning.partOfSpeech + "\n";
         meaning.definitions.forEach(definition => {
             toWrite += "        - " + definition.definition + "\n";
-            toWrite += "            - ex: " + definition.example + "\n";
+            if(definition.example){
+                toWrite += "            - ex: " + definition.example + "\n";
+            }
             if (definition.synonyms !== undefined) {
                 isSynonymAvailable = true;
                 synonyms += " " + definition.synonyms[0];

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function writeMeaningToFile(inputStream, filename) {
         toWrite += "    - " + meaning.partOfSpeech + "\n";
         meaning.definitions.forEach(definition => {
             toWrite += "        - " + definition.definition + "\n";
-            if(definition.example){
+            if(definition.example !== undefined){
                 toWrite += "            - ex: " + definition.example + "\n";
             }
             if (definition.synonyms !== undefined) {


### PR DESCRIPTION
Fixes #1

Presence check added for `definition.example`, It will be written to file only if it exits